### PR TITLE
Add basic support for the theory of strings

### DIFF
--- a/ddsmt.py
+++ b/ddsmt.py
@@ -599,6 +599,35 @@ def ddsmt_main ():
                     elif succeeded == "realvar_{}".format(i):
                         break
 
+                ### String substitutions
+                if sf.is_str_logic():
+                    nsubst = _substitute_terms (
+                            lambda x: sf.zeroConstSNode(),
+                            lambda x: not x.is_const() \
+                                      and x.sort and x.sort.is_str_sort(),
+                            cmds[i], g_args.bfs, g_args.randomized,
+                            "  substitute String terms with '\"\"'")
+                    if nsubst:
+                        succeeded = "stremp_{}".format(i)
+                        nsubst_round += nsubst
+                        nterms_subst += nsubst
+                    elif succeeded == "stremp_{}".format(i):
+                        break
+                    nsubst = _substitute_terms (
+                            lambda x: sf.add_fresh_declfunCmdNode(x.sort),
+                            lambda x: not x.is_const()                    \
+                                      and x.sort and x.sort.is_str_sort() \
+                                      and not sf.is_substvar(x),
+                            cmds[i], g_args.bfs, g_args.randomized,
+                            "  substitute String terms with fresh variables",
+                            True)
+                    if nsubst:
+                        succeeded = "strvar_{}".format(i)
+                        nsubst_round += nsubst
+                        nterms_subst += nsubst
+                    elif succeeded == "strvar_{}".format(i):
+                        break
+
                 ### Core substitutions
                 nsubst = _substitute_terms (
                         lambda x: x.children[-1].get_subst(),

--- a/parser/test/regtests/string-ops.smt2
+++ b/parser/test/regtests/string-ops.smt2
@@ -1,0 +1,7 @@
+(set-logic SLIA)
+(declare-const x String)
+(declare-const n Int)
+(declare-const z String)
+(assert (= (str.indexof (str.substr x n (str.len x)) "a" 5) 10))
+(assert (str.prefixof (str.++ x "A") "AB"))
+(assert (and (str.suffixof x "AB") (str.contains "A" (str.replace x "B" "C"))))


### PR DESCRIPTION
This commit adds support for eight common string operators (`str.len`,
`str.++`, `str.contains`, `str.substr`, `str.replace`, `str.indexof`,
`str.prefixof`, `str.suffixof`) and adds two passes. The first pass tries to
replace terms of sort String with the empty string and the second one
tries to replace terms of sort String with a fresh variable. The
standard for the theory of strings has not been finalized, so the commit
does not implement all proposed operators but rather a subset of
operators that are commonly used.